### PR TITLE
Explain UPSERT "properties that can't be change in update phase"

### DIFF
--- a/source/includes/api/v2/departments/_upsert.md
+++ b/source/includes/api/v2/departments/_upsert.md
@@ -56,4 +56,4 @@ location_id        |  ✓        | ✗            | Location's ID
 
 ✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
 
-Properties such as `location_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `location_id` but result in an HTTP 422 if the value is changed.
+Properties such as `location_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `location_id` but result in an HTTP 422 if the value has changed.

--- a/source/includes/api/v2/departments/_upsert.md
+++ b/source/includes/api/v2/departments/_upsert.md
@@ -54,5 +54,6 @@ external_id        |  ✓        | ✓            | An idenfier for a Department
 name               |  ✓        | ○            | Department's name
 location_id        |  ✓        | ✗            | Location's ID
 
-✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Ignored
+✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
 
+Properties such as `location_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `location_id` but result in an HTTP 422 if the value is changed.

--- a/source/includes/api/v2/job_sites/_upsert.md
+++ b/source/includes/api/v2/job_sites/_upsert.md
@@ -52,5 +52,7 @@ external_id        |  ○        | ○            | An identifier for a Job Site
 name               |  ✓        | ○            | Job Site's name
 department_id      |  ✓        | ✗            | Department to which the Job Site belongs
 
-✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Ignored
+✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
+
+Properties such as `department_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `department_id` but result in an HTTP 422 if the value is changed.
 

--- a/source/includes/api/v2/job_sites/_upsert.md
+++ b/source/includes/api/v2/job_sites/_upsert.md
@@ -54,5 +54,5 @@ department_id      |  ✓        | ✗            | Department to which the Job 
 
 ✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
 
-Properties such as `department_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `department_id` but result in an HTTP 422 if the value is changed.
+Properties such as `department_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `department_id` but result in an HTTP 422 if the value has changed.
 

--- a/source/includes/api/v2/locations/_upsert.md
+++ b/source/includes/api/v2/locations/_upsert.md
@@ -52,5 +52,7 @@ name               |  ✓        | ○            | Location's name
 time_zone          |  ✓        | ✗            | Location's time zone
 week_starts_on     |  ○        | ✗            | A value from 0 to 6 indicating which day of the week the calendar
 
-✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Ignored
+✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
+
+Properties such as `time_zone` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `time_zone` but result in an HTTP 422 if the value is changed.
 

--- a/source/includes/api/v2/locations/_upsert.md
+++ b/source/includes/api/v2/locations/_upsert.md
@@ -54,5 +54,5 @@ week_starts_on     |  ○        | ✗            | A value from 0 to 6 indicati
 
 ✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
 
-Properties such as `time_zone` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `time_zone` but result in an HTTP 422 if the value is changed.
+Properties such as `time_zone` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `time_zone` but result in an HTTP 422 if the value has changed.
 

--- a/source/includes/api/v2/positions/_upsert.md
+++ b/source/includes/api/v2/positions/_upsert.md
@@ -51,5 +51,7 @@ api_id             |  ✓        | ✓            | A unique identifier for a Po
 name               |  ✓        | ○            | Position's name
 department_id      |  ✓        | ✗            | Department to which the Position belongs
 
-✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Ignored
+✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
+
+Properties such as `department_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `department_id` but result in an HTTP 422 if the value is changed.
 

--- a/source/includes/api/v2/positions/_upsert.md
+++ b/source/includes/api/v2/positions/_upsert.md
@@ -53,5 +53,5 @@ department_id      |  ✓        | ✗            | Department to which the Posi
 
 ✓ = Required &nbsp; ○ = Optional &nbsp; ✗ = Cannot be changed
 
-Properties such as `department_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `department_id` but result in an HTTP 422 if the value is changed.
+Properties such as `department_id` are required for creation but cannot be changed during an update. An UPSERT will allow passing the **same** value for `department_id` but result in an HTTP 422 if the value has changed.
 


### PR DESCRIPTION
# Summary

For all UPSERT endpoints I've added something like this:

![image](https://user-images.githubusercontent.com/772968/59627205-84711680-90f2-11e9-81f7-709ddc0c76ae.png)
