### PR TITLE
Fix documentation copy/paste issue around `published_at`

### DIFF
--- a/source/includes/api/v2/shifts/_index.md
+++ b/source/includes/api/v2/shifts/_index.md
@@ -104,8 +104,8 @@ date | `?filter[shift][date](eq)='2018-12-11'` | The start date of a shift (ISO8
 starts_at | `?filter[shift][starts_at](ge)='2018-09-28 01:00:00 UTC'` | The start time of a Shift
 ends_at | `?filter[shift][ends_at](ge)='2018-09-29 04:30:00 UTC'` | The end time of a Shift
 updated_at | `?filter[shift][updated_at](ge)=2018-10-03` | Find Shifts that have been updated since a certain date (ISO8601 format)
-published_at | `?filter[shift][updated_at](ge)=2018-10-03` | Find Shifts that have been pulished since a certain date (ISO8601 format)
-published | `?filter[shift][updated_at](ge)=true` | Find Shifts that have been published
+published_at | `?filter[shift][published_at](ge)=2018-10-03` | Find Shifts that have been pulished since a certain date (ISO8601 format)
+published | `?filter[shift][published](ge)=true` | Find Shifts that have been published
 
 ### Sortable Properties
 

--- a/source/includes/api/v2/shifts/_index.md
+++ b/source/includes/api/v2/shifts/_index.md
@@ -104,7 +104,7 @@ date | `?filter[shift][date](eq)='2018-12-11'` | The start date of a shift (ISO8
 starts_at | `?filter[shift][starts_at](ge)='2018-09-28 01:00:00 UTC'` | The start time of a Shift
 ends_at | `?filter[shift][ends_at](ge)='2018-09-29 04:30:00 UTC'` | The end time of a Shift
 updated_at | `?filter[shift][updated_at](ge)=2018-10-03` | Find Shifts that have been updated since a certain date (ISO8601 format)
-published_at | `?filter[shift][published_at](ge)=2018-10-03` | Find Shifts that have been pulished since a certain date (ISO8601 format)
+published_at | `?filter[shift][published_at](ge)=2018-10-03` | Find Shifts that have been published since a certain date (ISO8601 format)
 published | `?filter[shift][published](ge)=true` | Find Shifts that have been published
 
 ### Sortable Properties


### PR DESCRIPTION
# Summary

These were wrong.

![image](https://user-images.githubusercontent.com/772968/61969292-03c5f580-af8f-11e9-9ae1-b099f02c648b.png)
